### PR TITLE
Implement effect calculations with bootstrap CIs

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pytest
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+from pycausalimpact import CausalImpactPy
 from pycausalimpact.utils import validate_periods, split_pre_post
 
 
@@ -37,3 +38,42 @@ def test_validate_periods_out_of_range():
     post = (3, 5)
     with pytest.raises(ValueError):
         validate_periods(df, pre, post)
+
+
+class MeanModel:
+    def fit(self, X, y):
+        self.mean_ = float(y.mean())
+
+    def predict(self, X):
+        return pd.Series(self.mean_, index=X.index)
+
+
+def test_effects_and_ci_dimensions():
+    df = pd.DataFrame({"y": [1, 2, 3, 4, 5, 6]})
+    pre = (0, 2)
+    post = (3, 5)
+    impact = CausalImpactPy(
+        df,
+        index=None,
+        y=["y"],
+        pre_period=pre,
+        post_period=post,
+        model=MeanModel(),
+    )
+    impact.run(n_sim=200)
+    res = impact.results
+
+    assert list(res.index) == [3, 4, 5]
+    assert res["point_effect"].tolist() == [2, 3, 4]
+    assert res["cumulative_effect"].tolist() == [2, 5, 9]
+    assert res["relative_effect"].round(2).tolist() == [1.0, 1.5, 2.0]
+
+    for col in [
+        "predicted_lower",
+        "predicted_upper",
+        "point_effect_lower",
+        "point_effect_upper",
+    ]:
+        assert col in res.columns
+        assert len(res[col]) == len(res)
+


### PR DESCRIPTION
## Summary
- Add a full implementation of `CausalImpactPy.run` including fitting, prediction and bootstrap-based intervals
- Compute point, cumulative, average and relative effects with associated confidence intervals
- Expand tests to validate effect calculations and confidence interval dimensions

## Testing
- `pytest -q`
