### PR TITLE
Add reporting summary table and plotting functionality

### DIFF
--- a/pycausalimpact/reporting.py
+++ b/pycausalimpact/reporting.py
@@ -19,10 +19,157 @@ class ReportGenerator:
 
     def _build_summary_table(self):
         """Compute average, cumulative effects and confidence intervals."""
-        # TODO: Aggregate observed, predicted, effect, and CIs
-        pass
+        df = self.results
+
+        avg_obs = df["observed"].mean()
+        cum_obs = df["observed"].sum()
+
+        avg_pred = df["predicted"].mean()
+        cum_pred = df["predicted"].sum()
+
+        avg_pred_lower = (
+            df["predicted_lower"].mean() if "predicted_lower" in df.columns else pd.NA
+        )
+        cum_pred_lower = (
+            df["predicted_lower"].sum() if "predicted_lower" in df.columns else pd.NA
+        )
+        avg_pred_upper = (
+            df["predicted_upper"].mean() if "predicted_upper" in df.columns else pd.NA
+        )
+        cum_pred_upper = (
+            df["predicted_upper"].sum() if "predicted_upper" in df.columns else pd.NA
+        )
+
+        avg_abs = df["point_effect"].mean()
+        avg_abs_lower = (
+            df["point_effect_lower"].mean() if "point_effect_lower" in df.columns else pd.NA
+        )
+        avg_abs_upper = (
+            df["point_effect_upper"].mean() if "point_effect_upper" in df.columns else pd.NA
+        )
+
+        cum_abs = df["cumulative_effect"].iloc[-1]
+        cum_abs_lower = (
+            df["cumulative_effect_lower"].iloc[-1]
+            if "cumulative_effect_lower" in df.columns
+            else pd.NA
+        )
+        cum_abs_upper = (
+            df["cumulative_effect_upper"].iloc[-1]
+            if "cumulative_effect_upper" in df.columns
+            else pd.NA
+        )
+
+        avg_rel = avg_abs / avg_pred if avg_pred != 0 else pd.NA
+        cum_rel = cum_abs / cum_pred if cum_pred != 0 else pd.NA
+
+        avg_rel_lower = (
+            avg_abs_lower / avg_pred_upper
+            if (
+                "point_effect_lower" in df.columns
+                and "predicted_upper" in df.columns
+                and not pd.isna(avg_pred_upper)
+                and avg_pred_upper != 0
+            )
+            else pd.NA
+        )
+        avg_rel_upper = (
+            avg_abs_upper / avg_pred_lower
+            if (
+                "point_effect_upper" in df.columns
+                and "predicted_lower" in df.columns
+                and not pd.isna(avg_pred_lower)
+                and avg_pred_lower != 0
+            )
+            else pd.NA
+        )
+
+        cum_rel_lower = (
+            cum_abs_lower / cum_pred_upper
+            if (
+                "cumulative_effect_lower" in df.columns
+                and "predicted_upper" in df.columns
+                and not pd.isna(cum_pred_upper)
+                and cum_pred_upper != 0
+            )
+            else pd.NA
+        )
+        cum_rel_upper = (
+            cum_abs_upper / cum_pred_lower
+            if (
+                "cumulative_effect_upper" in df.columns
+                and "predicted_lower" in df.columns
+                and not pd.isna(cum_pred_lower)
+                and cum_pred_lower != 0
+            )
+            else pd.NA
+        )
+
+        summary = pd.DataFrame(
+            {
+                "observed": [avg_obs, cum_obs],
+                "predicted": [avg_pred, cum_pred],
+                "predicted_lower": [avg_pred_lower, cum_pred_lower],
+                "predicted_upper": [avg_pred_upper, cum_pred_upper],
+                "abs_effect": [avg_abs, cum_abs],
+                "abs_effect_lower": [avg_abs_lower, cum_abs_lower],
+                "abs_effect_upper": [avg_abs_upper, cum_abs_upper],
+                "rel_effect": [avg_rel, cum_rel],
+                "rel_effect_lower": [avg_rel_lower, cum_rel_lower],
+                "rel_effect_upper": [avg_rel_upper, cum_rel_upper],
+            },
+            index=["average", "cumulative"],
+        )
+
+        return summary
 
     def _plot_results(self):
         """3-panel plot: observed vs predicted, pointwise effect, cumulative effect."""
-        # TODO: Implement matplotlib plotting
-        pass
+        df = self.results
+        fig, axes = plt.subplots(3, 1, figsize=(10, 8), sharex=True)
+
+        ax = axes[0]
+        ax.plot(df.index, df["observed"], label="observed")
+        ax.plot(df.index, df["predicted"], label="predicted")
+        if "predicted_lower" in df.columns and "predicted_upper" in df.columns:
+            ax.fill_between(
+                df.index,
+                df["predicted_lower"],
+                df["predicted_upper"],
+                color="gray",
+                alpha=0.3,
+            )
+        ax.set_title("Observed vs Predicted")
+        ax.legend()
+
+        ax = axes[1]
+        ax.plot(df.index, df["point_effect"], label="pointwise effect")
+        if "point_effect_lower" in df.columns and "point_effect_upper" in df.columns:
+            ax.fill_between(
+                df.index,
+                df["point_effect_lower"],
+                df["point_effect_upper"],
+                color="gray",
+                alpha=0.3,
+            )
+        ax.axhline(0, color="black", linewidth=1)
+        ax.set_title("Pointwise Effect")
+
+        ax = axes[2]
+        ax.plot(df.index, df["cumulative_effect"], label="cumulative effect")
+        if (
+            "cumulative_effect_lower" in df.columns
+            and "cumulative_effect_upper" in df.columns
+        ):
+            ax.fill_between(
+                df.index,
+                df["cumulative_effect_lower"],
+                df["cumulative_effect_upper"],
+                color="gray",
+                alpha=0.3,
+            )
+        ax.axhline(0, color="black", linewidth=1)
+        ax.set_title("Cumulative Effect")
+
+        plt.tight_layout()
+        return fig

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,0 +1,65 @@
+import pathlib
+import sys
+
+import pandas as pd
+import matplotlib
+matplotlib.use("Agg")
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from pycausalimpact import CausalImpactPy
+from pycausalimpact.reporting import ReportGenerator
+
+
+class MeanModel:
+    def fit(self, X, y):
+        self.mean_ = float(y.mean())
+
+    def predict(self, X):
+        return pd.Series(self.mean_, index=X.index)
+
+
+def _generate_results():
+    df = pd.DataFrame({"y": [1, 2, 3, 4, 5, 6]})
+    impact = CausalImpactPy(
+        df,
+        index=None,
+        y=["y"],
+        pre_period=(0, 2),
+        post_period=(3, 5),
+        model=MeanModel(),
+    )
+    return impact.run(n_sim=200)
+
+
+def test_summary_table_structure_and_values():
+    results = _generate_results()
+    report = ReportGenerator(results)
+    summary = report.generate(plot=False)
+
+    expected_cols = [
+        "observed",
+        "predicted",
+        "predicted_lower",
+        "predicted_upper",
+        "abs_effect",
+        "abs_effect_lower",
+        "abs_effect_upper",
+        "rel_effect",
+        "rel_effect_lower",
+        "rel_effect_upper",
+    ]
+
+    assert list(summary.index) == ["average", "cumulative"]
+    assert list(summary.columns) == expected_cols
+    assert summary.loc["average", "observed"] == pytest.approx(5.0)
+    assert summary.loc["average", "abs_effect"] == pytest.approx(3.0)
+    assert summary.loc["cumulative", "abs_effect"] == pytest.approx(9.0)
+    assert summary.loc["cumulative", "rel_effect"] == pytest.approx(1.5)
+
+
+def test_plotting_runs_without_error():
+    results = _generate_results()
+    report = ReportGenerator(results)
+    report.generate(plot=True)  # Should not raise


### PR DESCRIPTION
## Summary
- compute averages, cumulative totals, and relative effects with confidence intervals in `ReportGenerator`
- add matplotlib plotting for observed vs predicted, pointwise, and cumulative effects
- provide tests for report generation and plotting

## Testing
- `pytest -q`