### PR TITLE
Support exogenous data in Statsmodels adapter

### DIFF
--- a/pycausalimpact/models/statsmodels.py
+++ b/pycausalimpact/models/statsmodels.py
@@ -11,12 +11,13 @@ class StatsmodelsAdapter(BaseForecastModel):
         self.fitted = None
 
     def fit(self, y: pd.Series, X: pd.DataFrame = None):
-        self.fitted = self.model.fit()
+        model = self.model(y, exog=X)
+        self.fitted = model.fit()
         return self
 
     def predict(self, steps: int, X: pd.DataFrame = None):
-        return self.fitted.forecast(steps=steps)
+        return self.fitted.forecast(steps=steps, exog=X)
 
     def predict_interval(self, steps: int, X: pd.DataFrame = None, alpha: float = 0.05):
-        forecast = self.fitted.get_forecast(steps=steps)
+        forecast = self.fitted.get_forecast(steps=steps, exog=X)
         return forecast.conf_int(alpha=alpha)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3,6 +3,7 @@ import sys
 
 import pandas as pd
 import pytest
+from functools import partial
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 from pycausalimpact import CausalImpactPy
@@ -84,7 +85,7 @@ def test_statsmodels_adapter_integration():
     df = pd.DataFrame({"y": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]})
     pre = (0, 5)
     post = (6, 9)
-    model = ARIMA(df["y"][pre[0] : pre[1] + 1], order=(1, 0, 0))
+    model = partial(ARIMA, order=(1, 0, 0))
     adapter = StatsmodelsAdapter(model)
 
     impact = CausalImpactPy(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,24 @@
+import pandas as pd
+from functools import partial
+
+from statsmodels.tsa.arima.model import ARIMA
+
+from pycausalimpact.models.statsmodels import StatsmodelsAdapter
+
+
+def test_statsmodels_adapter_forecast_with_exog():
+    y = pd.Series(range(10))
+    X = pd.DataFrame({"x": range(10)})
+
+    pre_y, post_y = y[:8], y[8:]
+    pre_X, post_X = X[:8], X[8:]
+
+    adapter = StatsmodelsAdapter(partial(ARIMA, order=(1, 0, 0)))
+    adapter.fit(pre_y, X=pre_X)
+    result = adapter.predict(steps=len(post_y), X=post_X)
+
+    manual = ARIMA(pre_y, exog=pre_X, order=(1, 0, 0)).fit()
+    expected = manual.forecast(steps=len(post_y), exog=post_X)
+
+    pd.testing.assert_series_equal(result, expected)
+


### PR DESCRIPTION
## Summary
- Instantiate Statsmodels models with both endogenous and exogenous data
- Pass exogenous features to forecasting and interval methods
- Add tests covering exogenous forecasting and update integration test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892cb25194c8331bcffb3c968cdfb2d