### PR TITLE
Add exogenous regressor handling and interval standardization across adapters

### DIFF
--- a/pycausalimpact/models/base.py
+++ b/pycausalimpact/models/base.py
@@ -20,4 +20,4 @@ class BaseForecastModel(ABC):
         """
         Optional: return prediction intervals if the model supports it.
         """
-        raise NotImplementedError
+        raise NotImplementedError("Prediction intervals not supported for this model.")

--- a/pycausalimpact/models/prophet.py
+++ b/pycausalimpact/models/prophet.py
@@ -8,20 +8,39 @@ class ProphetAdapter(BaseForecastModel):
 
     def __init__(self, model):
         self.model = model
+        self._use_exog = False
+        self._X = None
 
     def fit(self, y: pd.Series, X: pd.DataFrame = None):
-        df = pd.DataFrame({"ds": y.index, "y": y})
+        df = pd.DataFrame({"ds": y.index, "y": y.values}).reset_index(drop=True)
         if X is not None:
-            df = pd.concat([df, X.reset_index(drop=True)], axis=1)
+            X = X.reset_index(drop=True)
+            if hasattr(self.model, "add_regressor"):
+                for col in X.columns:
+                    self.model.add_regressor(col)
+            df = pd.concat([df, X], axis=1)
+            self._use_exog = True
+            self._X = X
         self.model.fit(df)
         return self
 
+    def _prepare_future(self, steps: int, X: pd.DataFrame = None) -> pd.DataFrame:
+        future = self.model.make_future_dataframe(periods=steps, freq="D").reset_index(drop=True)
+        if self._use_exog:
+            if X is None:
+                raise ValueError("Exogenous data must be provided for prediction.")
+            future_exog = pd.concat([self._X, X.reset_index(drop=True)], axis=0)
+            future = pd.concat([future, future_exog.reset_index(drop=True)], axis=1)
+        return future
+
     def predict(self, steps: int, X: pd.DataFrame = None):
-        future = self.model.make_future_dataframe(periods=steps, freq='D')
+        future = self._prepare_future(steps, X=X)
         forecast = self.model.predict(future)
         return forecast["yhat"].iloc[-steps:]
 
     def predict_interval(self, steps: int, X: pd.DataFrame = None, alpha: float = 0.05):
-        future = self.model.make_future_dataframe(periods=steps, freq='D')
+        future = self._prepare_future(steps, X=X)
         forecast = self.model.predict(future)
-        return forecast[["yhat_lower", "yhat_upper"]].iloc[-steps:]
+        interval = forecast[["yhat_lower", "yhat_upper"]].iloc[-steps:]
+        interval.columns = ["lower", "upper"]
+        return interval

--- a/pycausalimpact/models/sktime.py
+++ b/pycausalimpact/models/sktime.py
@@ -8,10 +8,30 @@ class SktimeAdapter(BaseForecastModel):
 
     def __init__(self, model):
         self.model = model
+        self._use_exog = False
 
     def fit(self, y: pd.Series, X: pd.DataFrame = None):
         self.model.fit(y, X=X)
+        self._use_exog = X is not None
         return self
 
     def predict(self, steps: int, X: pd.DataFrame = None):
+        if self._use_exog and X is None:
+            raise ValueError("Exogenous data must be provided for prediction.")
         return self.model.predict(fh=range(1, steps+1), X=X)
+
+    def predict_interval(self, steps: int, X: pd.DataFrame = None, alpha: float = 0.05):
+        if not hasattr(self.model, "predict_interval"):
+            raise NotImplementedError(
+                "Prediction intervals not supported by this sktime model."
+            )
+        if self._use_exog and X is None:
+            raise ValueError("Exogenous data must be provided for prediction.")
+        intervals = self.model.predict_interval(
+            fh=range(1, steps + 1), X=X, coverage=1 - alpha
+        )
+        first_var = intervals.columns.get_level_values(0)[0]
+        coverage = intervals.columns.get_level_values(1)[0]
+        df = intervals[first_var, coverage]
+        df.columns = ["lower", "upper"]
+        return df

--- a/pycausalimpact/models/statsmodels.py
+++ b/pycausalimpact/models/statsmodels.py
@@ -9,15 +9,27 @@ class StatsmodelsAdapter(BaseForecastModel):
     def __init__(self, model):
         self.model = model
         self.fitted = None
+        self._use_exog = False
 
     def fit(self, y: pd.Series, X: pd.DataFrame = None):
         model = self.model(y, exog=X)
         self.fitted = model.fit()
+        self._use_exog = X is not None
         return self
 
     def predict(self, steps: int, X: pd.DataFrame = None):
+        if self._use_exog and X is None:
+            raise ValueError("Exogenous data must be provided for prediction.")
         return self.fitted.forecast(steps=steps, exog=X)
 
     def predict_interval(self, steps: int, X: pd.DataFrame = None, alpha: float = 0.05):
+        if not hasattr(self.fitted, "get_forecast"):
+            raise NotImplementedError(
+                "Prediction intervals not supported by this statsmodels model."
+            )
+        if self._use_exog and X is None:
+            raise ValueError("Exogenous data must be provided for prediction.")
         forecast = self.fitted.get_forecast(steps=steps, exog=X)
-        return forecast.conf_int(alpha=alpha)
+        ci = forecast.conf_int(alpha=alpha)
+        ci.columns = ["lower", "upper"]
+        return ci

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,9 +1,12 @@
 import pandas as pd
+import pytest
 from functools import partial
 
 from statsmodels.tsa.arima.model import ARIMA
 
 from pycausalimpact.models.statsmodels import StatsmodelsAdapter
+from pycausalimpact.models.prophet import ProphetAdapter
+from pycausalimpact.models.sktime import SktimeAdapter
 
 
 def test_statsmodels_adapter_forecast_with_exog():
@@ -21,4 +24,91 @@ def test_statsmodels_adapter_forecast_with_exog():
     expected = manual.forecast(steps=len(post_y), exog=post_X)
 
     pd.testing.assert_series_equal(result, expected)
+
+
+def test_statsmodels_adapter_interval_dataframe():
+    y = pd.Series(range(10))
+    X = pd.DataFrame({"x": range(10)})
+
+    adapter = StatsmodelsAdapter(partial(ARIMA, order=(1, 0, 0)))
+    adapter.fit(y[:8], X=X[:8])
+    interval = adapter.predict_interval(steps=2, X=X[8:])
+
+    assert list(interval.columns) == ["lower", "upper"]
+    assert len(interval) == 2
+
+
+class MockProphet:
+    def __init__(self):
+        self.fit_df = None
+        self.predict_df = None
+
+    def add_regressor(self, name):
+        pass
+
+    def fit(self, df):
+        self.fit_df = df
+
+    def make_future_dataframe(self, periods, freq):
+        return pd.DataFrame({"ds": range(len(self.fit_df) + periods)})
+
+    def predict(self, df):
+        self.predict_df = df
+        n = len(df)
+        return pd.DataFrame({
+            "ds": df["ds"],
+            "yhat": range(n),
+            "yhat_lower": range(n),
+            "yhat_upper": range(n),
+        })
+
+
+def test_prophet_adapter_handles_exog_and_interval():
+    y = pd.Series(range(5))
+    X = pd.DataFrame({"x": range(5)})
+    future_X = pd.DataFrame({"x": [5, 6]})
+
+    model = MockProphet()
+    adapter = ProphetAdapter(model)
+
+    adapter.fit(y, X=X)
+    pred = adapter.predict(steps=2, X=future_X)
+    interval = adapter.predict_interval(steps=2, X=future_X)
+
+    # ensure exogenous data passed through
+    assert "x" in model.fit_df.columns
+    assert model.predict_df["x"].iloc[-2:].reset_index(drop=True).equals(future_X["x"])
+    assert list(interval.columns) == ["lower", "upper"]
+    assert list(pred) == [5, 6]
+
+
+class MockSktimeModel:
+    def __init__(self):
+        self.fit_X = None
+        self.predict_X = None
+
+    def fit(self, y, X=None):
+        self.fit_X = X
+
+    def predict(self, fh, X=None):
+        self.predict_X = X
+        return pd.Series([0] * len(fh))
+
+
+def test_sktime_adapter_exog_and_interval_error():
+    y = pd.Series(range(5))
+    X = pd.DataFrame({"x": range(5)})
+    future_X = X.iloc[-2:]
+
+    model = MockSktimeModel()
+    adapter = SktimeAdapter(model)
+
+    adapter.fit(y, X=X)
+    adapter.predict(steps=2, X=future_X)
+
+    assert model.fit_X.equals(X)
+    assert model.predict_X.equals(future_X)
+
+    with pytest.raises(NotImplementedError):
+        adapter.predict_interval(steps=2, X=future_X)
 


### PR DESCRIPTION
## Summary
- Enforce explicit error when prediction intervals are unsupported
- Track exogenous usage and validate inputs across statsmodels, prophet, and sktime adapters
- Standardize interval outputs and implement tests using mock models

## Testing
- `PYTHONPATH=. pytest -q`
