### PR TITLE
feat: add narrative summary with significance

### DIFF
--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -67,3 +67,14 @@ def test_plotting_runs_without_error():
     results = _generate_results()
     report = ReportGenerator(results)
     report.generate(plot=True)  # Should not raise
+
+
+def test_narrative_generation():
+    results = _generate_results()
+    report = ReportGenerator(results)
+    summary, narrative = report.generate(plot=False, narrative=True)
+
+    assert isinstance(narrative, str)
+    # narrative should mention average effect and significance
+    assert "3.00" in narrative
+    assert "statistically significant" in narrative


### PR DESCRIPTION
## Summary
- extend reporting summary table with p-values and causal probabilities
- allow generating narrative text about effect and significance
- test statistical outputs and narrative generation

## Testing
- `pytest -q`
