### PR TITLE
docs: expand README with install guide and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,17 @@
 - **Visual and textual reporting:** Built-in `summary()` method provides a textual summary, a metrics table, and a 3-panel visualization (observed vs. predicted, pointwise effect, cumulative effect).
 - **Compatible with univariate or multivariate time series:** Supports models with or without exogenous regressors (control variables).
 
+## Installation
+
+```bash
+pip install pycausalimpact
+
+# or from source
+git clone https://github.com/pycausalimpact/PyCausalImpact.git
+cd PyCausalImpact
+pip install -e .
+```
+
 ## Usage Overview
 
 ```python
@@ -40,20 +51,71 @@ This will:
 3. Calculate pointwise, average, and cumulative causal effects with confidence intervals.
 4. Output a **visual and textual report** of the estimated causal impact.
 
+## Parameters
+
+`CausalImpactPy` accepts the following arguments:
+
+- `data` (`pd.DataFrame`): Time series with the target column and optional controls.
+- `index` (`str | None`): Name of the column to use as the time index if the DataFrame isn't already indexed.
+- `y` (`list[str]`): Columns to use; the first is the target series, remaining columns are controls.
+- `pre_period` (`tuple`): `(start, end)` defining the pre-intervention period.
+- `post_period` (`tuple`): `(start, end)` defining the post-intervention period.
+- `model` (`Any`): Forecasting model instance exposing `fit` and `predict` methods.
+- `alpha` (`float`, optional): Significance level for confidence intervals; defaults to `0.05`.
+
+## End-to-End Example
+
+```python
+import numpy as np
+import pandas as pd
+from functools import partial
+from statsmodels.tsa.arima.model import ARIMA
+
+from pycausalimpact import CausalImpactPy
+from pycausalimpact.models.statsmodels import StatsmodelsAdapter
+
+# Synthetic data with an intervention after index 40
+np.random.seed(0)
+data = pd.Series(np.random.normal(size=60)).cumsum()
+data.iloc[40:] += 5
+df = pd.DataFrame({"y": data})
+
+pre_period = (0, 39)
+post_period = (40, 59)
+model = StatsmodelsAdapter(partial(ARIMA, order=(1, 0, 0)))
+
+impact = CausalImpactPy(
+    data=df,
+    index=None,
+    y=["y"],
+    pre_period=pre_period,
+    post_period=post_period,
+    model=model,
+)
+
+impact.run()
+impact.summary(plot=True)
+```
+
+See more runnable scripts in [`docs/examples/`](docs/examples/).
+
 ## Planned Features
 
-* Model wrappers for **Statsmodels**, **Prophet**, and **sktime** out of the box.
-* Bootstrapping-based confidence intervals for models lacking predictive intervals.
-* Narrative-style report generation for executive summaries.
-* Extended plotting options (matplotlib, seaborn, or Plotly).
+- [x] Model wrappers for **Statsmodels**, **Prophet**, and **sktime** out of the box.
+- [x] Bootstrapping-based confidence intervals for models lacking predictive intervals.
+- [x] Narrative-style report generation for executive summaries.
+- [ ] Extended plotting options (seaborn, Plotly, etc.).
+- [ ] Additional adapters for libraries such as **scikit-learn** or **Darts**.
 
 ## Roadmap
 
-* [ ] Core engine for causal effect estimation (v0.1)
-* [ ] Forecasting model adapters (Statsmodels, Prophet, sktime)
-* [ ] Reporting API (`summary`, `plot`)
-* [ ] Advanced statistical options (bootstrap, Bayesian models)
-* [ ] Release initial stable version (v1.0)
+- [x] Core engine for causal effect estimation (v0.1)
+- [x] Forecasting model adapters (Statsmodels, Prophet, sktime)
+- [x] Reporting API (`summary`, `plot`)
+- [ ] Advanced statistical options (Bayesian models, richer bootstrap methods)
+- [ ] Packaging and PyPI release
+- [ ] Additional model adapters and integrations
+- [ ] Release initial stable version (v1.0)
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,6 @@
+# PyCausalImpact Documentation
+
+Examples and additional guides for using PyCausalImpact live here.
+
+- [`examples/basic_usage.py`](examples/basic_usage.py) – minimal script showing how to estimate causal impact with a Statsmodels ARIMA model.
+

--- a/docs/examples/basic_usage.py
+++ b/docs/examples/basic_usage.py
@@ -1,0 +1,36 @@
+"""Minimal end-to-end example for PyCausalImpact."""
+
+import pathlib
+import sys
+from functools import partial
+
+import numpy as np
+import pandas as pd
+from statsmodels.tsa.arima.model import ARIMA
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+from pycausalimpact import CausalImpactPy
+from pycausalimpact.models.statsmodels import StatsmodelsAdapter
+
+# Generate synthetic data with an intervention after index 40
+np.random.seed(0)
+series = pd.Series(np.random.normal(size=60)).cumsum()
+series.iloc[40:] += 5
+
+df = pd.DataFrame({"y": series})
+pre_period = (0, 39)
+post_period = (40, 59)
+
+model = StatsmodelsAdapter(partial(ARIMA, order=(1, 0, 0)))
+impact = CausalImpactPy(
+    data=df,
+    index=None,
+    y=["y"],
+    pre_period=pre_period,
+    post_period=post_period,
+    model=model,
+)
+
+impact.run()
+print(impact.summary(plot=False))
+


### PR DESCRIPTION
## Summary
- add installation guide, parameter docs, and end-to-end ARIMA example to README
- document completed features and update roadmap
- provide docs/examples/basic_usage.py and docs/README.md for quick usage reference

## Testing
- `pytest`
- `python docs/examples/basic_usage.py`
