### PR TITLE
feat: support interval prediction via sktime quantiles

### DIFF
--- a/pycausalimpact/models/sktime.py
+++ b/pycausalimpact/models/sktime.py
@@ -21,18 +21,33 @@ class SktimeAdapter(BaseForecastModel):
             raise ValueError("Exogenous data must be provided for prediction.")
         return self.model.predict(fh=range(1, steps + 1), X=X)
 
-    def predict_interval(self, steps: int, X: pd.DataFrame = None, alpha: float = 0.05):
-        if not hasattr(self.model, "predict_interval"):
-            raise NotImplementedError(
-                "Prediction intervals not supported by this sktime model."
-            )
+    def predict_interval(
+        self, steps: int, X: pd.DataFrame = None, alpha: float = 0.05
+    ):
         if self._use_exog and X is None:
             raise ValueError("Exogenous data must be provided for prediction.")
-        intervals = self.model.predict_interval(
-            fh=range(1, steps + 1), X=X, coverage=1 - alpha
+
+        fh = range(1, steps + 1)
+
+        if hasattr(self.model, "predict_interval"):
+            intervals = self.model.predict_interval(fh=fh, X=X, coverage=1 - alpha)
+            first_var = intervals.columns.get_level_values(0)[0]
+            coverage = intervals.columns.get_level_values(1)[0]
+            df = intervals[first_var, coverage]
+            df.columns = ["lower", "upper"]
+            return df
+
+        if hasattr(self.model, "predict_quantiles"):
+            lower_q = alpha / 2
+            upper_q = 1 - alpha / 2
+            quantiles = self.model.predict_quantiles(
+                fh=fh, X=X, alpha=[lower_q, upper_q]
+            )
+            first_var = quantiles.columns.get_level_values(0)[0]
+            df = quantiles[first_var][[lower_q, upper_q]]
+            df.columns = ["lower", "upper"]
+            return df
+
+        raise NotImplementedError(
+            "Prediction intervals not supported by this sktime model."
         )
-        first_var = intervals.columns.get_level_values(0)[0]
-        coverage = intervals.columns.get_level_values(1)[0]
-        df = intervals[first_var, coverage]
-        df.columns = ["lower", "upper"]
-        return df


### PR DESCRIPTION
## Summary
- add `predict_interval` to `SktimeAdapter` with fallback to `predict_quantiles`
- enhance `CausalImpactPy.run` to consume model-provided intervals or quantiles
- extend unit tests for sktime interval handling and core integration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893ca1171ac83318af9e52554af9131