### PR TITLE
Add random_state parameter for bootstrap reproducibility

### DIFF
--- a/pycausalimpact/core.py
+++ b/pycausalimpact/core.py
@@ -54,7 +54,7 @@ class CausalImpactPy:
             self.data, self.pre_period, self.post_period
         )
 
-    def run(self, n_sim: int = 1000):
+    def run(self, n_sim: int = 1000, random_state: Optional[int] = 0):
         """Fit model and generate counterfactual predictions for post period.
 
         Parameters
@@ -62,6 +62,9 @@ class CausalImpactPy:
         n_sim: int, optional
             Number of bootstrap simulations to use when model lacks prediction
             intervals. Defaults to ``1000``.
+        random_state: int, optional
+            Seed for the random number generator used during bootstrapping.
+            Defaults to ``0``.
         """
 
         y_col = self.y_cols[0]
@@ -154,7 +157,7 @@ class CausalImpactPy:
 
         if y_pred_lower is None or y_pred_upper is None:
             y_pred_lower, y_pred_upper = self._bootstrap_intervals(
-                residuals, y_pred_post, n_sim
+                residuals, y_pred_post, n_sim, random_state
             )
 
         self.results = self._compute_effects(
@@ -167,10 +170,11 @@ class CausalImpactPy:
         residuals: pd.Series,
         y_pred_post: pd.Series,
         n_sim: int,
+        random_state: Optional[int] = 0,
     ) -> Tuple[pd.Series, pd.Series]:
         """Generate prediction intervals via residual bootstrapping."""
 
-        rng = np.random.default_rng(0)
+        rng = np.random.default_rng(random_state)
         sims = rng.choice(
             residuals.values,
             size=(n_sim, len(y_pred_post)),

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -84,6 +84,31 @@ def test_effects_and_ci_dimensions():
         assert len(res[col]) == len(res)
 
 
+def test_random_state_reproducibility():
+    df = pd.DataFrame({"y": [1, 2, 3, 4, 5, 6]})
+    pre = (0, 2)
+    post = (3, 5)
+    impact1 = CausalImpactPy(
+        df,
+        index=None,
+        y=["y"],
+        pre_period=pre,
+        post_period=post,
+        model=MeanModel(),
+    )
+    impact2 = CausalImpactPy(
+        df,
+        index=None,
+        y=["y"],
+        pre_period=pre,
+        post_period=post,
+        model=MeanModel(),
+    )
+    res1 = impact1.run(n_sim=200, random_state=42)
+    res2 = impact2.run(n_sim=200, random_state=42)
+    pd.testing.assert_frame_equal(res1, res2)
+
+
 def test_statsmodels_adapter_integration():
     df = pd.DataFrame({"y": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]})
     pre = (0, 5)


### PR DESCRIPTION
## Summary
- allow callers to set a `random_state` when running `CausalImpactPy`
- respect `random_state` in bootstrap interval generation
- test reproducibility of bootstrap intervals

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893cd6f59f08331a13c2ae0f57a9801