### PR TITLE
Handle empty exogenous data for statsmodels models

### DIFF
--- a/pycausalimpact/models/statsmodels.py
+++ b/pycausalimpact/models/statsmodels.py
@@ -13,24 +13,43 @@ class StatsmodelsAdapter(BaseForecastModel):
         self._use_exog = False
 
     def fit(self, y: pd.Series, X: pd.DataFrame = None):
-        model = self.model(y, exog=X)
+        # Treat empty DataFrames as missing exogenous data
+        if isinstance(X, pd.DataFrame) and X.shape[1] == 0:
+            X = None
+
+        if X is not None:
+            model = self.model(y, exog=X)
+        else:
+            model = self.model(y)
+
         self.fitted = model.fit()
         self._use_exog = X is not None
         return self
 
     def predict(self, steps: int, X: pd.DataFrame = None):
-        if self._use_exog and X is None:
-            raise ValueError("Exogenous data must be provided for prediction.")
-        return self.fitted.forecast(steps=steps, exog=X)
+        if isinstance(X, pd.DataFrame) and X.shape[1] == 0:
+            X = None
+
+        if self._use_exog:
+            if X is None:
+                raise ValueError("Exogenous data must be provided for prediction.")
+            return self.fitted.forecast(steps=steps, exog=X)
+        return self.fitted.forecast(steps=steps)
 
     def predict_interval(self, steps: int, X: pd.DataFrame = None, alpha: float = 0.05):
         if not hasattr(self.fitted, "get_forecast"):
             raise NotImplementedError(
                 "Prediction intervals not supported by this statsmodels model."
             )
-        if self._use_exog and X is None:
-            raise ValueError("Exogenous data must be provided for prediction.")
-        forecast = self.fitted.get_forecast(steps=steps, exog=X)
+        if isinstance(X, pd.DataFrame) and X.shape[1] == 0:
+            X = None
+
+        if self._use_exog:
+            if X is None:
+                raise ValueError("Exogenous data must be provided for prediction.")
+            forecast = self.fitted.get_forecast(steps=steps, exog=X)
+        else:
+            forecast = self.fitted.get_forecast(steps=steps)
         ci = forecast.conf_int(alpha=alpha)
         ci.columns = ["lower", "upper"]
         return ci

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -170,3 +170,23 @@ def test_sktime_adapter_integration():
     res = impact.run()
     assert res["predicted_lower"].tolist() == [-1, -1, -1]
     assert res["predicted_upper"].tolist() == [1, 1, 1]
+
+
+def test_causalimpact_no_exog_statsmodels():
+    df = pd.DataFrame({"y": [1, 2, 3, 4, 5, 6]})
+    pre = (0, 2)
+    post = (3, 5)
+    adapter = StatsmodelsAdapter(partial(ARIMA, order=(1, 0, 0)))
+
+    impact = CausalImpactPy(
+        df,
+        index=None,
+        y=["y"],
+        pre_period=pre,
+        post_period=post,
+        model=adapter,
+    )
+
+    res = impact.run()
+    assert len(res) == (post[1] - post[0] + 1)
+    assert impact.model._use_exog is False

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -26,6 +26,23 @@ def test_statsmodels_adapter_fit_predict_interval():
     assert len(interval) == 2
 
 
+def test_statsmodels_adapter_no_exog():
+    y = pd.Series(range(10))
+    empty_X = pd.DataFrame(index=y.index)
+
+    adapter = StatsmodelsAdapter(partial(ARIMA, order=(1, 0, 0)))
+    adapter.fit(y, X=empty_X)
+
+    # After fitting with empty X, exogenous data shouldn't be required
+    assert adapter._use_exog is False
+    pred = adapter.predict(steps=2)
+    interval = adapter.predict_interval(steps=2)
+
+    assert len(pred) == 2
+    assert list(interval.columns) == ["lower", "upper"]
+    assert len(interval) == 2
+
+
 class MockProphet:
     def __init__(self):
         self.fit_df = None


### PR DESCRIPTION
## Summary
- Ignore empty exogenous DataFrames in `StatsmodelsAdapter`
- Call statsmodels forecast methods without exog when no exogenous features
- Test `StatsmodelsAdapter` and `CausalImpactPy` behaviour without exogenous data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6896d710825883319ac28de40479602c