### PR TITLE
Add TensorFlow Probability structural time series adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Key Features
 
-- **Flexible forecasting backend:** Use models from libraries such as **Statsmodels**, **Prophet**, **sktime**, **Darts**, or any compatible `fit/predict` estimator.
+- **Flexible forecasting backend:** Use models from libraries such as **Statsmodels**, **Prophet**, **sktime**, **TensorFlow Probability**, **Darts**, or any compatible `fit/predict` estimator.
 - **Causal effect estimation:** Compute the difference between observed and predicted values after an intervention.
 - **Rich statistical outputs:**
   - Pointwise causal effect (observed – predicted)
@@ -101,7 +101,7 @@ See more runnable scripts in [`docs/examples/`](docs/examples/).
 
 ## Planned Features
 
-- [x] Model wrappers for **Statsmodels**, **Prophet**, and **sktime** out of the box.
+- [x] Model wrappers for **Statsmodels**, **Prophet**, **sktime**, and **TensorFlow Probability** out of the box.
 - [x] Bootstrapping-based confidence intervals for models lacking predictive intervals.
 - [x] Narrative-style report generation for executive summaries.
 - [ ] Extended plotting options (seaborn, Plotly, etc.).

--- a/pycausalimpact/models/__init__.py
+++ b/pycausalimpact/models/__init__.py
@@ -1,0 +1,11 @@
+from .statsmodels import StatsmodelsAdapter
+from .prophet import ProphetAdapter
+from .sktime import SktimeAdapter
+from .tfp import TFPStructuralTimeSeries
+
+__all__ = [
+    "StatsmodelsAdapter",
+    "ProphetAdapter",
+    "SktimeAdapter",
+    "TFPStructuralTimeSeries",
+]

--- a/pycausalimpact/models/tfp.py
+++ b/pycausalimpact/models/tfp.py
@@ -1,0 +1,117 @@
+import numpy as np
+import pandas as pd
+import tensorflow as tf
+import tensorflow_probability as tfp
+
+from .base import BaseForecastModel
+
+
+tfd = tfp.distributions
+sts = tfp.sts
+
+
+class TFPStructuralTimeSeries(BaseForecastModel):
+    """Adapter for TensorFlow Probability structural time series models."""
+
+    def __init__(
+        self,
+        num_variational_steps: int = 200,
+        num_results: int = 100,
+        num_warmup_steps: int = 100,
+        use_hmc: bool = False,
+    ):
+        self.num_variational_steps = num_variational_steps
+        self.num_results = num_results
+        self.num_warmup_steps = num_warmup_steps
+        self.use_hmc = use_hmc
+
+        self._model = None
+        self._surrogate_posterior = None
+        self._posterior_samples = None
+        self._y = None
+        self._design_matrix = None
+
+    def _build_model(self, y: np.ndarray, design_matrix: np.ndarray | None):
+        components = [sts.LocalLinearTrend(observed_time_series=y)]
+        if design_matrix is not None:
+            components.append(sts.LinearRegression(design_matrix=design_matrix))
+        return sts.Sum(components, observed_time_series=y)
+
+    def fit(self, y: pd.Series, X: pd.DataFrame = None):
+        if isinstance(X, pd.DataFrame) and X.shape[1] == 0:
+            X = None
+        self._y = y.to_numpy(dtype=np.float32)
+        self._design_matrix = (
+            X.to_numpy(dtype=np.float32) if X is not None else None
+        )
+        self._model = self._build_model(self._y, self._design_matrix)
+
+        target_log_prob_fn = self._model.joint_log_prob(observed_time_series=self._y)
+        surrogate_posterior = sts.build_factored_surrogate_posterior(self._model)
+        optimizer = tf.optimizers.Adam(0.1)
+        tfp.vi.fit_surrogate_posterior(
+            target_log_prob_fn=target_log_prob_fn,
+            surrogate_posterior=surrogate_posterior,
+            optimizer=optimizer,
+            num_steps=self.num_variational_steps,
+        )
+        self._surrogate_posterior = surrogate_posterior
+
+        if self.use_hmc:
+            @tf.function
+            def _target_log_prob_fn(*params):
+                return target_log_prob_fn(*params)
+
+            current_state = surrogate_posterior.sample()
+            kernel = tfp.mcmc.HamiltonianMonteCarlo(
+                target_log_prob_fn=_target_log_prob_fn,
+                num_leapfrog_steps=3,
+                step_size=0.1,
+            )
+            self._posterior_samples = tfp.mcmc.sample_chain(
+                num_results=self.num_results,
+                num_burnin_steps=self.num_warmup_steps,
+                current_state=current_state,
+                kernel=kernel,
+                trace_fn=None,
+            )
+        else:
+            self._posterior_samples = surrogate_posterior.sample(self.num_results)
+
+        return self
+
+    def _forecast_dist(self, steps: int, X: pd.DataFrame | None):
+        if self._y is None:
+            raise ValueError("Model must be fit before prediction.")
+
+        if self._design_matrix is not None:
+            if X is None:
+                X_future = np.zeros((steps, self._design_matrix.shape[1]), dtype=np.float32)
+            else:
+                X_future = X.to_numpy(dtype=np.float32)
+            design_matrix = np.vstack([self._design_matrix, X_future])
+        else:
+            design_matrix = None
+
+        y_full = np.concatenate([self._y, np.zeros(steps, dtype=np.float32)])
+        model = self._build_model(y_full, design_matrix)
+        return sts.forecast(
+            model,
+            self._y,
+            self._posterior_samples,
+            num_steps_forecast=steps,
+        )
+
+    def predict(self, steps: int, X: pd.DataFrame = None):
+        forecast_dist = self._forecast_dist(steps, X)
+        mean = forecast_dist.mean().numpy().squeeze(-1)
+        return pd.Series(mean, index=range(steps))
+
+    def predict_interval(
+        self, steps: int, X: pd.DataFrame = None, alpha: float = 0.05
+    ):
+        forecast_dist = self._forecast_dist(steps, X)
+        samples = forecast_dist.sample(self.num_results).numpy().squeeze(-1)
+        lower = np.quantile(samples, alpha / 2, axis=0)
+        upper = np.quantile(samples, 1 - alpha / 2, axis=0)
+        return pd.DataFrame({"lower": lower, "upper": upper})

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -7,6 +7,7 @@ from statsmodels.tsa.arima.model import ARIMA
 from pycausalimpact.models.statsmodels import StatsmodelsAdapter
 from pycausalimpact.models.prophet import ProphetAdapter
 from pycausalimpact.models.sktime import SktimeAdapter
+from pycausalimpact.models.tfp import TFPStructuralTimeSeries
 
 
 def test_statsmodels_adapter_fit_predict_interval():
@@ -195,3 +196,17 @@ def test_sktime_adapter_predict_quantiles_interval():
     assert list(interval.columns) == ["lower", "upper"]
     assert interval["lower"].tolist() == [-1, -1]
     assert interval["upper"].tolist() == [1, 1]
+
+
+def test_tfp_adapter_fit_predict_interval():
+    y = pd.Series(range(8), dtype=float)
+    X = pd.DataFrame({"x": range(8)}, dtype=float)
+
+    adapter = TFPStructuralTimeSeries(num_variational_steps=5, num_results=5)
+    adapter.fit(y[:6], X[:6])
+    pred = adapter.predict(steps=2, X=X[6:])
+    interval = adapter.predict_interval(steps=2, X=X[6:])
+
+    assert len(pred) == 2
+    assert list(interval.columns) == ["lower", "upper"]
+    assert len(interval) == 2


### PR DESCRIPTION
## Summary
- add `TFPStructuralTimeSeries` adapter powered by TensorFlow Probability STS
- expose new adapter in `pycausalimpact.models`
- document TensorFlow Probability support and add unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896dbd001c8833199b6728b003d5c21