### PR TITLE
Add inference method option for TFP models

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -172,6 +172,22 @@ def test_sktime_adapter_integration():
     assert res["predicted_upper"].tolist() == [1, 1, 1]
 
 
+def test_invalid_inference_method():
+    df = pd.DataFrame({"y": [1, 2, 3, 4]})
+    pre = (0, 1)
+    post = (2, 3)
+    with pytest.raises(ValueError):
+        CausalImpactPy(
+            df,
+            index=None,
+            y=["y"],
+            pre_period=pre,
+            post_period=post,
+            model=MeanModel(),
+            inference_method="invalid",
+        )
+
+
 def test_causalimpact_no_exog_statsmodels():
     df = pd.DataFrame({"y": [1, 2, 3, 4, 5, 6]})
     pre = (0, 2)


### PR DESCRIPTION
## Summary
- allow choosing `inference_method` (variational or hmc) via `CausalImpactPy` and forward it to TFP models
- add support for `inference_method` in `TFPStructuralTimeSeries` with validation
- cover invalid/forwarded inference method behaviour in tests

## Testing
- `pre-commit run --files pycausalimpact/core.py pycausalimpact/models/tfp.py tests/test_core.py tests/test_models.py` *(fails: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags'))*
- `black pycausalimpact/core.py pycausalimpact/models/tfp.py tests/test_core.py tests/test_models.py`
- `flake8 pycausalimpact/core.py pycausalimpact/models/tfp.py tests/test_core.py tests/test_models.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896f7a05ac483319a55f42c49ce9f18