### PR TITLE
Add TensorFlow Probability inference tests and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,24 @@ jobs:
       - name: Upgrade pip
         run: python -m pip install -U pip setuptools wheel
       - name: Install dependencies
-        run: pip install .[test]
+        run: |
+          pip install .[statsmodels,prophet,sktime]
+          pip install pytest
       - name: Run tests
-        run: pytest
+        run: pytest -m "not tfp"
+
+  test-tfp:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '3.12'
+      - name: Upgrade pip
+        run: python -m pip install -U pip setuptools wheel
+      - name: Install TensorFlow Probability extra
+        run: |
+          pip install .[tfp]
+          pip install pytest
+      - name: Run tfp tests
+        run: pytest -m tfp

--- a/README.md
+++ b/README.md
@@ -32,6 +32,22 @@ To enable TensorFlow Probability-based models, install the optional `tfp` extra:
 pip install pycausalimpact[tfp]
 ```
 
+## Multiple Inference Methods
+
+The TensorFlow Probability adapter supports multiple inference algorithms.
+Variational inference is used by default, while Hamiltonian Monte Carlo (HMC)
+is available for more exact posterior sampling:
+
+```python
+from pycausalimpact.models import TFPStructuralTimeSeries
+
+# Variational inference (default)
+model_vi = TFPStructuralTimeSeries()
+
+# Hamiltonian Monte Carlo
+model_hmc = TFPStructuralTimeSeries(inference_method="hmc")
+```
+
 ## Usage Overview
 
 ```python

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,8 @@ Examples and additional guides for using PyCausalImpact live here.
 - [`examples/basic_usage.ipynb`](examples/basic_usage.ipynb) –
   minimal script showing how to estimate causal impact with a
   Statsmodels ARIMA model.
+- [`examples/tfp_multiple_inference.ipynb`](examples/tfp_multiple_inference.ipynb) –
+  demonstrates TensorFlow Probability models with variational and HMC inference.
 
 ## Summary Output
 
@@ -29,22 +31,38 @@ Together these metrics summarise both the magnitude and the statistical signific
 
 ## Running Backend Tests
 
-The test suite uses markers to target specific forecasting backends. After installing the optional dependencies with:
+The test suite uses markers to target specific forecasting backends.
+Install core optional dependencies and run all non-TFP tests with:
 
 ```
-pip install .[test]
+pip install .[statsmodels,prophet,sktime] pytest
+pytest -q -m "not tfp"
 ```
 
-run all tests via `pytest -q`.
-
-To skip slower TensorFlow Probability tests:
+Tests requiring TensorFlow Probability need its extra dependency:
 
 ```
-pytest -q -m "not heavy"
+pip install .[tfp] pytest
+pytest -q -m tfp
 ```
 
 To run tests for a single backend:
 
 ```
 pytest -q -k statsmodels   # or prophet, sktime, tfp
+```
+
+## Multiple Inference Methods
+
+The TensorFlow Probability adapter supports both variational inference and
+Hamiltonian Monte Carlo (HMC):
+
+```python
+from pycausalimpact.models import TFPStructuralTimeSeries
+
+# Variational inference (default)
+model_vi = TFPStructuralTimeSeries()
+
+# Hamiltonian Monte Carlo
+model_hmc = TFPStructuralTimeSeries(inference_method="hmc")
 ```

--- a/docs/examples/tfp_multiple_inference.ipynb
+++ b/docs/examples/tfp_multiple_inference.ipynb
@@ -1,0 +1,62 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "57411b6a",
+   "metadata": {},
+   "source": [
+    "# TFP Inference Methods\n",
+    "This notebook demonstrates using both variational inference and Hamiltonian Monte Carlo with the TensorFlow Probability adapter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8003d919",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from pycausalimpact import CausalImpactPy\n",
+    "from pycausalimpact.models import TFPStructuralTimeSeries\n",
+    "\n",
+    "np.random.seed(0)\n",
+    "n = 30\n",
+    "series = pd.Series(np.sin(np.linspace(0, 3 * np.pi, n)) + np.random.normal(scale=0.1, size=n))\n",
+    "data = pd.DataFrame({\"y\": series})\n",
+    "pre_period = (0, 19)\n",
+    "post_period = (20, 29)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "389b02ba",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Variational inference\n",
+    "model_vi = TFPStructuralTimeSeries(num_variational_steps=50, num_results=50)\n",
+    "impact_vi = CausalImpactPy(data=data, index=None, y=[\"y\"], pre_period=pre_period, post_period=post_period, model=model_vi)\n",
+    "impact_vi.run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "af427f39",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Hamiltonian Monte Carlo\n",
+    "model_hmc = TFPStructuralTimeSeries(inference_method=\"hmc\", num_variational_steps=50, num_results=50, num_warmup_steps=50)\n",
+    "impact_hmc = CausalImpactPy(data=data, index=None, y=[\"y\"], pre_period=pre_period, post_period=post_period, model=model_hmc, inference_method=\"hmc\")\n",
+    "impact_hmc.run()"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,4 @@
 markers =
     backend(name): mark tests for a specific forecasting backend
     heavy: mark tests as slow or resource intensive
+    tfp: mark tests requiring TensorFlow Probability

--- a/tests/test_tfp_adapter.py
+++ b/tests/test_tfp_adapter.py
@@ -1,0 +1,41 @@
+import numpy as np
+import pandas as pd
+import pytest
+import tensorflow as tf
+
+from pycausalimpact import CausalImpactPy
+from pycausalimpact.models import TFPStructuralTimeSeries
+
+
+@pytest.mark.tfp
+@pytest.mark.parametrize("method", ["variational", "hmc"])
+def test_tfp_adapter_inference_methods(method):
+    np.random.seed(0)
+    tf.random.set_seed(0)
+    n = 30
+    series = pd.Series(
+        np.sin(np.linspace(0, 3 * np.pi, n)) + np.random.normal(scale=0.1, size=n)
+    )
+    data = pd.DataFrame({"y": series})
+    pre_period = (0, 19)
+    post_period = (20, 29)
+
+    model = TFPStructuralTimeSeries(
+        num_variational_steps=50,
+        num_results=20,
+        num_warmup_steps=20,
+        inference_method=method,
+    )
+    impact = CausalImpactPy(
+        data=data,
+        index=None,
+        y=["y"],
+        pre_period=pre_period,
+        post_period=post_period,
+        model=model,
+        inference_method=method,
+    )
+    results = impact.run()
+    assert results.shape[0] == post_period[1] - post_period[0] + 1
+    assert not results["predicted"].isna().any()
+    assert (results["predicted_upper"] > results["predicted_lower"]).all()


### PR DESCRIPTION
## Summary
- add dedicated TFP adapter tests covering variational and HMC inference
- document multiple inference methods in README and docs with new notebook example
- split CI to run core tests separately from TensorFlow Probability tests

## Testing
- `pytest -m "not tfp"`
- `pytest -m tfp`


------
https://chatgpt.com/codex/tasks/task_e_689702a8fdd48331aa5265ba6b2b1bcf